### PR TITLE
Switch to ComfyUI API (/upload/image, /history) for image up- and download

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A library for p5.js which adds support for interacting with ComfyUI, using its A
 
 ## Prerequisites
 
-* [ComfyUI](https://github.com/comfyanonymous/ComfyUI) (tested with v0.2.4)
+* [ComfyUI](https://github.com/comfyanonymous/ComfyUI) (tested with v0.4.51)
 * If you are running your own ComfyUI installation:
-    * Make sure to start Comfy with the following arguments: ```--listen 0.0.0.0 --enable-cors-header```
+    * Make sure to start Comfy with the following arguments: ```--listen 0.0.0.0 --enable-cors-header '*'```
     * If the site you will be accessing Comfy from uses HTTPS, you will need to provision a certificate, and load it into ComfyUI with ```--tls-keyfile privkey.pem --tls-certfile fullchain.pem```. This is needed if you want to make use of the p5.js web editor.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A library for p5.js which adds support for interacting with ComfyUI, using its A
 * Submit images or p5 drawing surfaces as inputs to workflows (e.g. for img2img, ...)
 * Easy to use API that supports multiple outputs as well
 * Works with promises or callbacks
-* Fast (uses WebSocket instead of file transfers)
 
 ## Reference
 
@@ -106,6 +105,16 @@ Alternatively, you can also use the `await` keyword to wait for the `run` method
 
 ```
 let results = await comfy.run(workflow);
+```
+
+You can also add a third (optional) parameter to receive status updates while the workflow is running:
+
+```
+comfy.run(workflow, gotImage, gotStatus);
+
+function gotStatus(status){
+  console.log(status);
+}
 ```
 
 #### Receiving results

--- a/examples/comfyui-basic/workflow_api.json
+++ b/examples/comfyui-basic/workflow_api.json
@@ -7,22 +7,10 @@
       "sampler_name": "euler",
       "scheduler": "normal",
       "denoise": 1,
-      "model": [
-        "4",
-        0
-      ],
-      "positive": [
-        "6",
-        0
-      ],
-      "negative": [
-        "7",
-        0
-      ],
-      "latent_image": [
-        "5",
-        0
-      ]
+      "model": ["4", 0],
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "latent_image": ["5", 0]
     },
     "class_type": "KSampler",
     "_meta": {
@@ -31,7 +19,7 @@
   },
   "4": {
     "inputs": {
-      "ckpt_name": "v1-5-pruned-emaonly.ckpt"
+      "ckpt_name": "v1-5-pruned-emaonly-fp16.safetensors"
     },
     "class_type": "CheckpointLoaderSimple",
     "_meta": {
@@ -52,10 +40,7 @@
   "6": {
     "inputs": {
       "text": "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,",
-      "clip": [
-        "4",
-        1
-      ]
+      "clip": ["4", 1]
     },
     "class_type": "CLIPTextEncode",
     "_meta": {
@@ -65,10 +50,7 @@
   "7": {
     "inputs": {
       "text": "text, watermark",
-      "clip": [
-        "4",
-        1
-      ]
+      "clip": ["4", 1]
     },
     "class_type": "CLIPTextEncode",
     "_meta": {
@@ -77,14 +59,8 @@
   },
   "8": {
     "inputs": {
-      "samples": [
-        "3",
-        0
-      ],
-      "vae": [
-        "4",
-        2
-      ]
+      "samples": ["3", 0],
+      "vae": ["4", 2]
     },
     "class_type": "VAEDecode",
     "_meta": {
@@ -94,10 +70,7 @@
   "9": {
     "inputs": {
       "filename_prefix": "ComfyUI",
-      "images": [
-        "8",
-        0
-      ]
+      "images": ["8", 0]
     },
     "class_type": "SaveImage",
     "_meta": {

--- a/libraries/p5.comfyui-helper.js
+++ b/libraries/p5.comfyui-helper.js
@@ -146,9 +146,9 @@ class ComfyUiP5Helper {
 
     return {
       inputs: {
-        image: data_url.split("base64,")[1],
+        data: data_url.split("base64,")[1],
       },
-      class_type: "ETN_LoadImageBase64",
+      class_type: "LoadImageFromBase64",
       _meta: {
         title: "Load Image (Base64)",
       },
@@ -168,7 +168,7 @@ class ComfyUiP5Helper {
       inputs: {
         image: data_url.split("base64,")[1],
       },
-      class_type: "ETN_LoadMaskBase64",
+      class_type: "LoadMaskFromBase64",
       _meta: {
         title: "Load Mask (Base64)",
       },

--- a/libraries/p5.comfyui-helper.js
+++ b/libraries/p5.comfyui-helper.js
@@ -20,6 +20,9 @@ class ComfyUiP5Helper {
   setup_websocket() {
     this.ws = new WebSocket(this.base_url + "/ws");
     this.ws.addEventListener("message", this.websocket_on_message.bind(this));
+    this.ws.addEventListener("error", this.websocket_on_error.bind(this));
+    this.ws.addEventListener("close", this.websocket_on_close.bind(this));
+    this.sid = null; // invalidate for reconnection
   }
 
   async websocket_on_message(event) {
@@ -81,6 +84,18 @@ class ComfyUiP5Helper {
         });
       }
     }
+  }
+
+  websocket_on_error(event) {
+    console.warn(event);
+    this.ws.close();
+  }
+
+  websocket_on_close(event) {
+    setTimeout(() => {
+      console.log("Reconnecting to " + this.base_url);
+      this.setup_websocket();
+    }, 1000);
   }
 
   async get_outputs_from_history(prompt_id) {

--- a/libraries/p5.comfyui-helper.js
+++ b/libraries/p5.comfyui-helper.js
@@ -220,30 +220,10 @@ class ComfyUiP5Helper {
       this.upload_canvas(canvas, filename).finally(() => {
         delete this.running_uploads[filename];
       });
+
+      return filename;
     } else {
       throw "image() is currently only implemented for p5 Graphics/Renderer/Image objects";
     }
-
-    return filename;
-  }
-
-  mask(img) {
-    let data_url;
-    if (img.loadPixels) {
-      img.loadPixels();
-      data_url = img.canvas.toDataURL();
-    } else {
-      throw "mask() is currently only implemented for p5 images";
-    }
-
-    return {
-      inputs: {
-        image: data_url.split("base64,")[1],
-      },
-      class_type: "LoadMaskFromBase64",
-      _meta: {
-        title: "Load Mask (Base64)",
-      },
-    };
   }
 }


### PR DESCRIPTION
Hi, love your library and use it a lot personally and when teaching p5.js + ComfyUI!

I just had a few hickups with it that I wanted to fix, so here's a PR with the changes. I think using the "proper" ComfyUI approaches to image up- and download (workflows staying intact in Comfy's queue and in the resulting images) outweigh the benefits of the SaveImageWebsocket/Load Image (Base64) approach.

Changes are:
- p5.comfyui-helper stalls until the ComfyUI connection is set up. This way, prompts can be triggered with .run() immediately without them going nowhere.
- uses the ComfyUI API /upload/image which leaves input images on the ComfyUI server for future retrievals/runs of the workflow
- instead of replacing *SaveImage* with *SaveImageWebsocket*, use the ComfyUI /history API instead. This way, workflows in Comfy's queue and stored in the resulting images stay as they are, instead of becoming transmogrified into websocket-based ones.
- no longer requires additional node packs installed (Load Mask (Base64) etc.)
- optional *status* callback for run() that returns the current status every step of the KSampler (useful for implementing status bars)